### PR TITLE
Integer mode now generates naturally spaced random values.

### DIFF
--- a/tests/test_distrand.py
+++ b/tests/test_distrand.py
@@ -31,3 +31,11 @@ def test_negative_distance_error():
 def test_dtype_casting():
     values = distrand(low=0, high=20, size=3, min_dist=5, dtype=float)
     assert values.dtype == np.float64
+    
+def test_int_mode_spacing_not_grid_aligned():
+    from distrand import distrand
+    nums = distrand(100, 200, size=6, min_dist=7, dtype=int)
+    assert len(nums) == 6
+    for i in range(len(nums)):
+        for j in range(i+1, len(nums)):
+            assert abs(nums[i] - nums[j]) >= 7


### PR DESCRIPTION
## 🛠️ Fix: Integer Mode Randomness

### ✅ Problem:

Previously, when using `int` mode, the generated values were grid-aligned to the `min_dist`.

* For example, using `min_dist = 10` would always return values like `510, 520, 530…` — all ending in 0.
* This removed the natural feel of randomness, as values were strictly tied to multiples of `min_dist`.

---

### 🎯 What’s Changed:

* Replaced grid-based `np.arange(..., min_dist)` with a randomized sampling strategy using shuffling.
* Now, the integer values are **still spaced by at least `min_dist`**, but:

  * They can end with any digit (0–9)
  * They feel more randomly distributed
  * They break away from rigid patterns

---

### 🔍 Impact:

* This improves **entropy and naturalness** of results in simulations and visualizations.
* Still guarantees spacing ≥ `min_dist`, so functional correctness is preserved.
* Float mode was unaffected — only `int` mode changed internally.
